### PR TITLE
Add removeAll function

### DIFF
--- a/src/react-minisearch.test.tsx
+++ b/src/react-minisearch.test.tsx
@@ -46,6 +46,7 @@ const ChildComponent: React.FC<UseMiniSearch<DocumentType>> = ({
   addAllAsync,
   remove,
   removeById,
+  removeAll,
   clearSearch,
   clearSuggestions
 }) => {
@@ -78,6 +79,9 @@ const ChildComponent: React.FC<UseMiniSearch<DocumentType>> = ({
       </button>
       <button className='remove-by-id' onClick={() => removeById(documentToRemove.uid)}>
         Remove by Id
+      </button>
+      <button className='remove-all' onClick={() => removeAll()}>
+        Remove All
       </button>
       <button className='clear' onClick={() => { clearSearch(); clearSuggestions() }}>
         Clear
@@ -187,6 +191,18 @@ const testComponent = (Component: React.FC<Props>) => {
 
     const items = wrap.update().find('.results li')
     expect(items).not.toExist()
+  })
+
+  it('removes all documents', () => {
+    const wrap = mount(<Component {...props} />)
+
+    wrap.find('button.remove-all').simulate('click')
+
+    ;['natura', 'selfish'].forEach((query) => {
+      wrap.find('input.search').simulate('change', { target: { value: query } })
+      const items = wrap.update().find('.results li')
+      expect(items).not.toExist()
+    })
   })
 
   it('clears search and auto suggestions', () => {

--- a/src/react-minisearch.tsx
+++ b/src/react-minisearch.tsx
@@ -11,6 +11,7 @@ export interface UseMiniSearch<T = object> {
   addAllAsync: (documents: T[], options?: { chunkSize?: number }) => Promise<void>,
   remove: (document: T) => void,
   removeById: (id: any) => void,
+  removeAll: (documents?: T[]) => void,
   isIndexing: boolean,
   clearSearch: () => void,
   clearSuggestions: () => void,
@@ -83,6 +84,10 @@ export function useMiniSearch<T = object> (documents: T[], options: Options<T>):
     setDocumentById(removeFromMap<T>(documentById, id))
   }
 
+  const removeAll = (documents: T[] = null) => {
+    documents ? miniSearch.removeAll(documents) : miniSearch.removeAll()
+  }
+
   const clearSearch = (): void => {
     setSearchResults(null)
   }
@@ -101,6 +106,7 @@ export function useMiniSearch<T = object> (documents: T[], options: Options<T>):
     addAllAsync,
     remove,
     removeById,
+    removeAll,
     isIndexing,
     clearSearch,
     clearSuggestions,


### PR DESCRIPTION
Hi Luca,

I added the `removeAll` function to `react-minisearch`: it's simply a wrapper around the MiniSearch `removeAll` function and, as the [original function](https://lucaong.github.io/minisearch/MiniSearch.html#removeAll), it can be called with an array of documents (to delete only those) or with no arguments (to delete all). 

BTW, `react-minisearch` is great, I love it :) 