### PR TITLE
Clear the map of ID to document when using removeAll

### DIFF
--- a/src/react-minisearch.test.tsx
+++ b/src/react-minisearch.test.tsx
@@ -209,6 +209,24 @@ const testComponent = (Component: React.FC<Props>) => {
     })
   })
 
+  it('removes all documents and re-adds some documents', () => {
+    const wrap = mount(<Component {...props} />)
+
+    wrap.find('button.remove-all').simulate('click')
+    wrap.find('button.add-all').simulate('click')
+
+    wrap.find('input.search').simulate('change', { target: { value: 'pieces' } })
+
+    const items = wrap.update().find('.results li')
+    expect(items).toHaveLength(2)
+
+    ;['natura', 'selfish'].forEach((query) => {
+      wrap.find('input.search').simulate('change', { target: { value: query } })
+      const items = wrap.update().find('.results li')
+      expect(items).not.toExist()
+    })
+  })
+
   it('clears search and auto suggestions', () => {
     const wrap = mount(<Component {...props} />)
 

--- a/src/react-minisearch.tsx
+++ b/src/react-minisearch.tsx
@@ -81,8 +81,15 @@ export function useMiniSearch<T = any> (documents: T[], options: Options<T>): Us
     setDocumentById(removeFromMap<T>(documentById, id))
   }
 
-  const removeAll = (documents: T[] = null) => {
-    documents ? miniSearch.removeAll(documents) : miniSearch.removeAll()
+  const removeAll = function (documents?: T[]): void {
+    if (arguments.length === 0) {
+      miniSearch.removeAll()
+      setDocumentById({})
+    } else {
+      miniSearch.removeAll(documents)
+      const idsToRemove = documents.map((doc) => extractField(doc, idField))
+      setDocumentById(removeManyFromMap<T>(documentById, idsToRemove))
+    }
   }
 
   const clearSearch = (): void => {
@@ -120,6 +127,14 @@ export function useMiniSearch<T = any> (documents: T[], options: Options<T>): Us
 function removeFromMap<T> (map: { [key: string]: T }, keyToRemove: any): { [key: string]: T } {
   const newMap = Object.assign({}, map)
   delete newMap[keyToRemove]
+  return newMap
+}
+
+function removeManyFromMap<T> (map: { [key: string]: T }, keysToRemove: any[]): { [key: string]: T } {
+  const newMap = Object.assign({}, map)
+  keysToRemove.forEach((keyToRemove) => {
+    delete newMap[keyToRemove]
+  })
   return newMap
 }
 


### PR DESCRIPTION
When using `removeAll`, the map of ID to document was not properly cleared. This PR fixes it.