### PR TITLE
Perf: avoid expensive removeAll on unmount

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ yarn add react-minisearch
 
 There are three main ways to use `react-minisearch`: the `useMiniSearch` hook, the `withMiniSearch` higher-order component, or the `WithMiniSearch` wrapper component.
 
+All three way take the following arguments (or props for the wrapper component):
+
+  - The initial collection of documents to add to the index. Note: this is just
+    the initial collection, and mutating this argument won't cause reindexing.
+    To add or remove documents after initialization, use the functions
+    `add`/`addAll`/`remove`/`removeAll`/`discard`, etc.
+  - The `MiniSearch` configuration options
+
 #### Using the useMiniSearch hook:
 
 ```jsx

--- a/src/react-minisearch.test.tsx
+++ b/src/react-minisearch.test.tsx
@@ -195,6 +195,10 @@ const testComponent = (Component: React.FC<Props>) => {
 
     const items = wrap.update().find('.results li')
     expect(items).not.toExist()
+
+    expect(() => {
+      wrap.unmount()
+    }).not.toThrow()
   })
 
   it('removes a document by id', () => {

--- a/src/react-minisearch.tsx
+++ b/src/react-minisearch.tsx
@@ -147,11 +147,7 @@ export function useMiniSearch<T = any> (documents: T[], options: Options<T>): Us
 
   useEffect(() => {
     utils.addAll(documents)
-
-    return () => {
-      utils.removeAll()
-    }
-  }, [utils, documents])
+  }, [utils]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
     searchResults,

--- a/src/react-minisearch.tsx
+++ b/src/react-minisearch.tsx
@@ -149,7 +149,7 @@ export function useMiniSearch<T = any> (documents: T[], options: Options<T>): Us
     utils.addAll(documents)
 
     return () => {
-      utils.removeAll(documents)
+      utils.removeAll()
     }
   }, [utils, documents])
 

--- a/src/react-minisearch.tsx
+++ b/src/react-minisearch.tsx
@@ -22,7 +22,7 @@ export interface UseMiniSearch<T = any> {
   miniSearch: MiniSearch<T>
 }
 
-export function useMiniSearch<T = any> (documents: T[], options: Options<T>): UseMiniSearch<T> {
+export function useMiniSearch<T = any> (documents: readonly T[], options: Options<T>): UseMiniSearch<T> {
   const optionsRef = useRef(options)
   const miniSearchRef = useRef<MiniSearch<T>>(new MiniSearch<T>(options))
   const documentByIdRef = useRef<{ [key: string]: T }>({})
@@ -147,7 +147,7 @@ export function useMiniSearch<T = any> (documents: T[], options: Options<T>): Us
 
   useEffect(() => {
     utils.addAll(documents)
-  }, [utils]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
     searchResults,


### PR DESCRIPTION
Calling `removeAll` with all documents is expensive for big collections. Also, the `documents` argument of `useMiniSearch` is intended to be the initial collection, and further changes to the index should be done with `add`/`remove`/etc.

The expensive removal of the previous documents upon unmount is therefore unnecessary, and is now avoided.

The documentation has also been updated to clarify that the `documents` argument is only used for initialization.

See https://github.com/lucaong/react-minisearch/issues/38