### PR TITLE
Publish separate ES, CJS, and UMD packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,17 @@
   "name": "react-minisearch",
   "version": "7.1.0",
   "description": "React integration for MiniSearch",
-  "main": "dist/react-minisearch.js",
+  "main": "dist/umd/react-minisearch.js",
+  "module": "dist/esm/react-minisearch.js",
+  "es2015": "dist/esm/react-minisearch.js",
+  "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/cjs/react-minisearch.cjs",
+      "import": "./dist/esm/react-minisearch.js",
+      "default": "./dist/esm/react-minisearch.js"
+    }
+  },
   "repository": "https://github.com/lucaong/react-minisearch",
   "author": "Luca Ongaro",
   "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,15 +11,27 @@ export default {
     commonjs(),
     typescript()
   ],
-  output: {
-    name: 'react-minisearch',
-    dir: './dist',
-    format: 'umd',
-    sourcemap: true,
-    exports: 'named',
-    globals: {
-      react: 'React',
-      minisearch: 'MiniSearch'
+  output: [
+    {
+      name: 'react-minisearch',
+      file: './dist/umd/react-minisearch.js',
+      format: 'umd',
+      sourcemap: true,
+      exports: 'named',
+      globals: {
+        react: 'React',
+        minisearch: 'MiniSearch'
+      }
+    },
+    {
+      file: './dist/esm/react-minisearch.js',
+      format: 'es',
+      sourcemap: true
+    },
+    {
+      file: './dist/cjs/react-minisearch.cjs',
+      format: 'cjs',
+      sourcemap: true
     }
-  }
+  ]
 }


### PR DESCRIPTION
This should better serve different needs, and also solve https://github.com/lucaong/react-minisearch/issues/42