### PR TITLE
Addition of getById to access documents added to index

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ for all three ways (`useMiniSearch`, `withMiniSearch`, or `WithMiniSearch`):
   - `addAllAsync(documents: T[], options?: object) => Promise<void>`: same as
     `addAll`, but works asynchronously and in batches to avoid blocking the UI
 
+  - `getById(id: any) => T | null`: function to retrieve a document from the index
+    by its ID
+
   - `remove(document: T) => void`: function to remove a document from the index
 
   - `removeById(id: any) => void`: function to remove a document from the index

--- a/src/react-minisearch.test.tsx
+++ b/src/react-minisearch.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 import { mount } from 'enzyme'
-import React, { ChangeEvent, useEffect } from 'react'
+import React, { ChangeEvent, useEffect, useState } from 'react'
 import { act } from 'react-dom/test-utils'
 import { useMiniSearch, withMiniSearch, WithMiniSearch, UseMiniSearch } from './react-minisearch'
 import MiniSearch, { Options } from 'minisearch'
@@ -47,6 +47,7 @@ const ChildComponent: React.FC<UseMiniSearch<DocumentType>> = ({
   add,
   addAll,
   addAllAsync,
+  getById,
   remove,
   removeById,
   removeAll,
@@ -55,6 +56,7 @@ const ChildComponent: React.FC<UseMiniSearch<DocumentType>> = ({
   clearSearch,
   clearSuggestions
 }) => {
+  const [docTitle, setDocTitle] = useState<string | null>(null)
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const query = event.target.value
     autoSuggest(query)
@@ -70,6 +72,7 @@ const ChildComponent: React.FC<UseMiniSearch<DocumentType>> = ({
       <ul className='results'>
         { searchResults && searchResults.map((result) => <li key={result.uid}>{ result.title }</li>) }
       </ul>
+      <div className='doc-title'>{ docTitle }</div>
       <button className='add' onClick={() => add(documentToAdd)}>
         Add One
       </button>
@@ -78,6 +81,9 @@ const ChildComponent: React.FC<UseMiniSearch<DocumentType>> = ({
       </button>
       <button className='add-all-async' onClick={() => { promise = addAllAsync(documentsToAdd) } }>
         Add All Async
+      </button>
+      <button className='get-by-id' onClick={() => setDocTitle(getById(documentToAdd.uid)?.title) }>
+        Get by Id
       </button>
       <button className='remove' onClick={() => remove(documentToRemove)}>
         Remove
@@ -203,6 +209,17 @@ const testComponent = (Component: React.FC<Props>) => {
     expect(items).toHaveLength(2)
     expect(items.first()).toHaveText(documentsToAdd[0].title)
     expect(items.last()).toHaveText(documentsToAdd[1].title)
+  })
+
+  it('gets a document by id', () => {
+    const wrap = mount(<Component {...props} />)
+
+    wrap.find('button.add').simulate('click')
+    wrap.find('button.get-by-id').simulate('click')
+
+    const items = wrap.update().find('.doc-title')
+    expect(items).toHaveLength(1)
+    expect(items.first()).toHaveText(documentToAdd.title)
   })
 
   it('removes a document', () => {

--- a/src/react-minisearch.tsx
+++ b/src/react-minisearch.tsx
@@ -10,6 +10,7 @@ export interface UseMiniSearch<T = any> {
   add: (document: T) => void,
   addAll: (documents: readonly T[]) => void,
   addAllAsync: (documents: readonly T[], options?: { chunkSize?: number }) => Promise<void>,
+  getById: (id: any) => T | null,
   remove: (document: T) => void,
   removeById: (id: any) => void,
   removeAll: (documents?: readonly T[]) => void,
@@ -47,7 +48,7 @@ export function useMiniSearch<T = any> (documents: readonly T[], options: Option
 
     const search = (query: string, searchOptions?: SearchOptions): void => {
       const results = miniSearch.search(query, searchOptions)
-      const searchResults = results.map(({ id }) => documentById[id])
+      const searchResults = results.map(({ id }) => getById(id))
       setSearchResults(searchResults)
       setRawResults(results)
     }
@@ -78,13 +79,17 @@ export function useMiniSearch<T = any> (documents: readonly T[], options: Option
       })
     }
 
+    const getById = (id: any): T | null => {
+      return documentById[id]
+    }
+
     const remove = (document: T): void => {
       miniSearch.remove(document)
       documentByIdRef.current = removeFromMap<T>(documentById, extractField(document, idField))
     }
 
     const removeById = (id: any): void => {
-      const document = documentById[id]
+      const document = getById(id)
       if (document == null) {
         throw new Error(`react-minisearch: document with id ${id} does not exist in the index`)
       }
@@ -133,6 +138,7 @@ export function useMiniSearch<T = any> (documents: readonly T[], options: Option
       add,
       addAll,
       addAllAsync,
+      getById,
       remove,
       removeById,
       removeAll,


### PR DESCRIPTION
Adds `getById` so documents added via hook can be retrieved in a similar fashion to the documents made available in `searchResults`. Resolves #49 